### PR TITLE
fix(api): persist solve() demand-probe intents to a real table

### DIFF
--- a/mission-control/apps/api/database/migrations/003_solve_intents.sql
+++ b/mission-control/apps/api/database/migrations/003_solve_intents.sql
@@ -1,0 +1,42 @@
+-- solve() Demand Probe Migration
+-- Migration: 003_solve_intents
+-- Created: 2026-05-29
+-- Description: Creates the solve_intents table backing POST /api/v1/intent
+--              (the /demo demand probe). Anonymous, best-effort intent capture
+--              used to validate demand for natural-language optimization routing
+--              before the router is built.
+--
+-- Run with: psql -d your_database -f 003_solve_intents.sql
+-- Or via Supabase Dashboard SQL Editor
+
+-- ============================================================================
+-- SOLVE INTENTS TABLE
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS solve_intents (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  prompt TEXT NOT NULL,
+  email TEXT,
+  source TEXT,
+  guessed_class TEXT,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Indexes for common query patterns (waitlist follow-up, demand analytics)
+CREATE INDEX IF NOT EXISTS idx_solve_intents_created_at ON solve_intents(created_at);
+CREATE INDEX IF NOT EXISTS idx_solve_intents_guessed_class ON solve_intents(guessed_class);
+CREATE INDEX IF NOT EXISTS idx_solve_intents_email ON solve_intents(email) WHERE email IS NOT NULL;
+
+-- ============================================================================
+-- ROW LEVEL SECURITY (RLS)
+-- ============================================================================
+-- This is an anonymous, server-only capture table (no user_id, no auth on the
+-- public endpoint). Enable RLS with no permissive policy so it is unreadable
+-- by the anon/authenticated client roles; only the service role (which bypasses
+-- RLS) inserts and reads it.
+
+ALTER TABLE solve_intents ENABLE ROW LEVEL SECURITY;
+
+-- ============================================================================
+-- MIGRATION COMPLETE
+-- ============================================================================

--- a/mission-control/apps/api/database/schema.sql
+++ b/mission-control/apps/api/database/schema.sql
@@ -4477,3 +4477,27 @@ WHERE status = 'pending';
 CREATE INDEX IF NOT EXISTS idx_oracle_execution_plans_active
 ON oracle_execution_plans(user_id, created_at DESC)
 WHERE status = 'active';
+
+-- ============================================================================
+-- SOLVE INTENTS TABLE (solve() demand probe — POST /api/v1/intent)
+-- ============================================================================
+-- Anonymous, best-effort intent capture from the /demo demand probe. Used to
+-- validate demand for natural-language optimization routing before the router
+-- is built. See migrations/003_solve_intents.sql.
+
+CREATE TABLE IF NOT EXISTS solve_intents (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  prompt TEXT NOT NULL,
+  email TEXT,
+  source TEXT,
+  guessed_class TEXT,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_solve_intents_created_at ON solve_intents(created_at);
+CREATE INDEX IF NOT EXISTS idx_solve_intents_guessed_class ON solve_intents(guessed_class);
+CREATE INDEX IF NOT EXISTS idx_solve_intents_email ON solve_intents(email) WHERE email IS NOT NULL;
+
+-- Anonymous server-only capture table: enable RLS with no permissive policy so
+-- only the service role (which bypasses RLS) can read/write it.
+ALTER TABLE solve_intents ENABLE ROW LEVEL SECURITY;

--- a/mission-control/apps/api/src/routes/oracle/api-public.ts
+++ b/mission-control/apps/api/src/routes/oracle/api-public.ts
@@ -157,6 +157,54 @@ const ForecastInputSchema = z.object({
   }
 });
 
+// ── solve() Intent Classifier ──────────────────────────
+//
+// Pure keyword-overlap guess of which algorithm class a free-text prompt maps
+// to. Mirrors the client-side teaser in web/app/demo/page.tsx so the captured
+// `guessed_class` column reflects the same routing the user was shown. Zero
+// network, zero LLM cost — just substring scoring.
+
+const INTENT_PROBLEM_CLASSES: ReadonlyArray<{ id: string; keywords: readonly string[] }> = [
+  { id: "multi_armed_bandit", keywords: ["a/b", "ab test", "variant", "explore", "exploit", "which option", "landing page", "best arm"] },
+  { id: "contextual_bandit", keywords: ["personalize", "context", "feature", "per user", "segment", "tailor"] },
+  { id: "thompson_sampling", keywords: ["thompson", "bayesian bandit", "posterior sampling", "conversion rate"] },
+  { id: "calibration", keywords: ["calibrat", "brier", "log score", "how accurate", "forecast accuracy", "reliability"] },
+  { id: "wilson_ci", keywords: ["confidence interval", "wilson", "proportion", "rate uncertainty", "margin of error"] },
+  { id: "beta_bernoulli", keywords: ["success rate", "click rate", "conversion", "binary outcome", "yes/no", "prior"] },
+  { id: "monte_carlo", keywords: ["monte carlo", "simulate", "simulation", "probability of", "what are the odds", "uncertainty", "distribution"] },
+  { id: "lp_mip", keywords: ["allocate", "schedule", "assign", "constraint", "maximize", "minimize", "budget", "capacity", "resource", "optimize"] },
+  { id: "anomaly_detection", keywords: ["anomaly", "outlier", "spike", "unusual", "fraud", "detect", "abnormal"] },
+  { id: "time_series_forecast", keywords: ["forecast", "predict next", "trend", "seasonal", "future value", "time series", "projection"] },
+  { id: "kalman_filter", keywords: ["kalman", "track", "noisy sensor", "smoothing", "state estimate", "filter"] },
+  { id: "pagerank", keywords: ["pagerank", "rank nodes", "importance", "influence", "centrality", "network rank"] },
+  { id: "community_detection", keywords: ["community", "cluster", "group", "segment graph", "louvain", "modularity"] },
+  { id: "shortest_path", keywords: ["shortest path", "route", "fastest way", "navigate", "critical path", "fewest steps"] },
+  { id: "hrp_portfolio", keywords: ["portfolio", "allocate assets", "diversif", "weights", "risk parity", "rebalance"] },
+  { id: "ensemble_convergence", keywords: ["ensemble", "combine models", "consensus", "agreement", "aggregate predictions", "multiple sources"] },
+  { id: "causal_entropy_balancing", keywords: ["causal", "treatment effect", "confound", "balance", "counterfactual", "impact of"] },
+  { id: "simulated_annealing", keywords: ["annealing", "global optimum", "rearrange", "layout", "tour", "combinatorial"] },
+  { id: "genetic_algorithm", keywords: ["genetic", "evolve", "evolution", "many variables", "tune parameters", "search space"] },
+  { id: "q_learning", keywords: ["q-learning", "reinforcement", "reward", "policy", "agent learns", "sequential decision"] },
+];
+
+export function guessIntentClass(prompt: string): string | null {
+  const text = prompt.toLowerCase();
+  if (text.trim().length < 4) return null;
+  let bestId: string | null = null;
+  let bestScore = 0;
+  for (const pc of INTENT_PROBLEM_CLASSES) {
+    let score = 0;
+    for (const kw of pc.keywords) {
+      if (text.includes(kw)) score += kw.includes(" ") ? 2 : 1;
+    }
+    if (score > bestScore) {
+      bestScore = score;
+      bestId = pc.id;
+    }
+  }
+  return bestScore > 0 ? bestId : null;
+}
+
 // ── Route Registration ─────────────────────────────────
 
 export default async function publicApiRoutes(fastify: FastifyInstance) {
@@ -297,18 +345,26 @@ export default async function publicApiRoutes(fastify: FastifyInstance) {
     const prompt = typeof body.prompt === "string" ? body.prompt.trim() : "";
     if (!prompt) return reply.status(400).send({ error: "prompt required (non-empty string)" });
     if (prompt.length > 2000) return reply.status(400).send({ error: "prompt too long (max 2000 chars)" });
-    const email = typeof body.email === "string" && /^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(body.email.trim())
-      ? body.email.trim() : undefined;
+    // Email is optional. If omitted/empty, no email is stored. If a non-empty
+    // value is supplied it must be a valid address — otherwise reject (400)
+    // rather than silently dropping it.
+    const rawEmail = typeof body.email === "string" ? body.email.trim() : "";
+    const emailValid = /^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(rawEmail);
+    if (rawEmail && !emailValid) {
+      return reply.status(400).send({ error: "invalid email" });
+    }
+    const email = emailValid ? rawEmail : undefined;
     const source = typeof body.source === "string" ? body.source.slice(0, 80) : undefined;
+    const guessedClass = guessIntentClass(prompt);
     const ts = Date.now();
 
-    fastify.log.info({ intent: { prompt, email, source, ts } }, "solve-intent");
+    fastify.log.info({ intent: { prompt, email, source, guessedClass, ts } }, "solve-intent");
 
     // Fire-and-forget persist — guarded so a missing table never errors the request.
     if (db.isConnected()) {
       db.query(
-        `INSERT INTO solve_intents (prompt, email, source, created_at) VALUES ($1, $2, $3, to_timestamp($4 / 1000.0))`,
-        [prompt, email ?? null, source ?? null, ts],
+        `INSERT INTO solve_intents (prompt, email, source, guessed_class, created_at) VALUES ($1, $2, $3, $4, to_timestamp($5 / 1000.0))`,
+        [prompt, email ?? null, source ?? null, guessedClass ?? null, ts],
       ).catch((err) => fastify.log.warn({ err }, "solve_intents insert failed (non-fatal)"));
     }
 

--- a/mission-control/apps/api/src/routes/oracle/intent.test.ts
+++ b/mission-control/apps/api/src/routes/oracle/intent.test.ts
@@ -1,0 +1,150 @@
+/**
+ * intent.test.ts
+ *
+ * Tests for POST /api/v1/intent — the solve() demand probe behind the /demo
+ * widget. Locks in the 2026-05-29 persistence fix (solve_intents table +
+ * guessed_class column) and the endpoint contract:
+ *   - valid submit returns 200 with the waitlist confirmation
+ *   - a present-but-invalid email is rejected with 400
+ *   - a prompt over 2000 chars is rejected with 400
+ *   - the persist path is fire-and-forget: even when the DB is connected and
+ *     the INSERT throws (e.g. missing table), the request still returns 200
+ *     (graceful degradation — intent is never lost, it is always logged).
+ */
+
+import { describe, it, expect, beforeAll, afterAll, afterEach, vi } from 'vitest';
+import Fastify, { type FastifyInstance } from 'fastify';
+import publicApiRoutes, { guessIntentClass } from './api-public';
+import { db } from '../../services/database/client';
+
+let app: FastifyInstance;
+
+beforeAll(async () => {
+  app = Fastify({ logger: false });
+  await app.register(publicApiRoutes);
+  await app.ready();
+});
+
+afterAll(async () => {
+  await app.close();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function postIntent(payload: Record<string, unknown>) {
+  return app.inject({
+    method: 'POST',
+    url: '/api/v1/intent',
+    payload,
+  });
+}
+
+describe('POST /api/v1/intent — valid submit', () => {
+  it('returns 200 with the waitlist confirmation for a valid prompt + email', async () => {
+    const res = await postIntent({
+      prompt: 'I need to allocate a $50k marketing budget across channels to maximize signups',
+      email: 'founder@example.com',
+      source: 'demo-page',
+    });
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.payload);
+    expect(body.status).toBe('received');
+    expect(body.message).toMatch(/waitlist/i);
+  });
+
+  it('returns 200 when email is omitted (email is optional)', async () => {
+    const res = await postIntent({
+      prompt: 'detect anomalies in my server response times',
+      source: 'demo-page',
+    });
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.payload).status).toBe('received');
+  });
+});
+
+describe('POST /api/v1/intent — invalid email rejected', () => {
+  it('returns 400 when a non-empty email is malformed', async () => {
+    const res = await postIntent({
+      prompt: 'optimize my portfolio weights',
+      email: 'not-an-email',
+    });
+    expect(res.statusCode).toBe(400);
+    const body = JSON.parse(res.payload);
+    expect(body.error).toMatch(/invalid email/i);
+  });
+});
+
+describe('POST /api/v1/intent — prompt length validation', () => {
+  it('returns 400 when prompt exceeds 2000 chars', async () => {
+    const res = await postIntent({
+      prompt: 'x'.repeat(2001),
+      source: 'demo-page',
+    });
+    expect(res.statusCode).toBe(400);
+    const body = JSON.parse(res.payload);
+    expect(body.error).toMatch(/too long/i);
+  });
+
+  it('returns 400 when prompt is empty', async () => {
+    const res = await postIntent({ prompt: '   ' });
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.payload).error).toMatch(/prompt required/i);
+  });
+});
+
+describe('POST /api/v1/intent — db-down path is graceful', () => {
+  it('returns 200 when the DB is disconnected (in-memory fallback, no persist attempt)', async () => {
+    // Default test environment: no DATABASE_URL → in-memory fallback →
+    // db.isConnected() is false, so no INSERT is attempted.
+    expect(db.isConnected()).toBe(false);
+    const res = await postIntent({
+      prompt: 'schedule 4 tasks into 3 time slots under capacity constraints',
+      source: 'demo-page',
+    });
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.payload).status).toBe('received');
+  });
+
+  it('still returns 200 when the DB is connected but the INSERT throws (fire-and-forget)', async () => {
+    vi.spyOn(db, 'isConnected').mockReturnValue(true);
+    const querySpy = vi
+      .spyOn(db, 'query')
+      .mockRejectedValue(new Error('relation "solve_intents" does not exist'));
+
+    const res = await postIntent({
+      prompt: 'forecast next month revenue from the time series',
+      email: 'lead@example.com',
+      source: 'demo-page',
+    });
+
+    // The request must succeed even though the persist rejected.
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.payload).status).toBe('received');
+    // And the handler did attempt the INSERT with the new column set.
+    expect(querySpy).toHaveBeenCalledTimes(1);
+    const [sql, params] = querySpy.mock.calls[0];
+    expect(sql).toMatch(/INSERT INTO solve_intents/);
+    expect(sql).toMatch(/guessed_class/);
+    // params: [prompt, email, source, guessed_class, ts]
+    expect(params).toHaveLength(5);
+    expect(params?.[1]).toBe('lead@example.com');
+    expect(params?.[2]).toBe('demo-page');
+  });
+});
+
+describe('guessIntentClass — server-side keyword classifier', () => {
+  it('maps an A/B testing prompt to multi_armed_bandit', () => {
+    expect(guessIntentClass('which landing page variant should get more traffic in my a/b test'))
+      .toBe('multi_armed_bandit');
+  });
+
+  it('returns null for a prompt with no keyword overlap', () => {
+    expect(guessIntentClass('hello there friend')).toBeNull();
+  });
+
+  it('returns null for a prompt that is too short', () => {
+    expect(guessIntentClass('hi')).toBeNull();
+  });
+});

--- a/web/app/demo/page.tsx
+++ b/web/app/demo/page.tsx
@@ -1278,6 +1278,12 @@ function SolveProbe() {
               </button>
             </div>
 
+            {/* GDPR / consent notice */}
+            <p className="text-xs font-mono text-gray-600">
+              We store your email only to notify you about the solve() beta. No
+              marketing, no third parties. Leave it blank to stay anonymous.
+            </p>
+
             {status === "error" && errorMsg && (
               <div className="text-xs font-mono text-red-400">{errorMsg}</div>
             )}


### PR DESCRIPTION
## What
The `/demo` demand-probe shipped, but `POST /api/v1/intent` inserted into a `solve_intents` table that did not exist — every persist silently failed (data survived only in Render stdout logs).

## Changes
- Add `003_solve_intents.sql` migration + matching `schema.sql` entry (id, prompt, email, source, guessed_class, created_at).
- Server-side `guessIntentClass()` populates `guessed_class`.
- 10 route tests (valid / invalid-email-400 / oversize-prompt-400 / db-down graceful-200 / fire-and-forget).
- GDPR consent line on the `/demo` widget.

## Follow-up (human)
Apply the migration to the live Render/Supabase DB for prod persistence.