### PR TITLE
fix(mcp): correct solve_schedule input schema to match the API contract

### DIFF
--- a/mission-control/packages/mcp-server/src/index.npm.ts
+++ b/mission-control/packages/mcp-server/src/index.npm.ts
@@ -390,11 +390,17 @@ const TOOLS = [
             properties: {
               id: { type: "string" },
               name: { type: "string" },
-              duration: { type: "number", description: "Required slot duration (minutes)." },
+              durationMinutes: { type: "number", description: "Required duration in minutes." },
               priority: { type: "number", description: "Higher = more important." },
-              energyRequired: { type: "number", minimum: 0, maximum: 1, description: "0..1 energy demand." },
+              energyRequired: {
+                type: "string",
+                enum: ["high", "medium", "low"],
+                description: "Energy demand.",
+              },
+              deadline: { type: "number", description: "Optional. Unix timestamp (ms)." },
+              category: { type: "string", description: "Optional." },
             },
-            required: ["id", "duration"],
+            required: ["id", "name", "durationMinutes", "priority", "energyRequired"],
           },
         },
         slots: {
@@ -404,11 +410,18 @@ const TOOLS = [
             type: "object",
             properties: {
               id: { type: "string" },
-              name: { type: "string" },
-              duration: { type: "number" },
-              energyLevel: { type: "number", minimum: 0, maximum: 1 },
+              startTime: {
+                type: "number",
+                description: "Slot start as a Unix timestamp (number, not a string like '09:00').",
+              },
+              durationMinutes: { type: "number", description: "Slot duration in minutes." },
+              energyLevel: {
+                type: "string",
+                enum: ["high", "medium", "low"],
+                description: "Slot energy level.",
+              },
             },
-            required: ["id", "duration"],
+            required: ["id", "startTime", "durationMinutes", "energyLevel"],
           },
         },
       },


### PR DESCRIPTION
## Problem
The published `solve_schedule` MCP tool advertised an input schema that does not match the API:
- `duration` (should be **`durationMinutes`**)
- `energyRequired`/`energyLevel` as `number` 0..1 (should be **string enum** `high|medium|low`)
- required only `["id","duration"]`, and **no `startTime`** on slots

The API (`/api/v1/solve/schedule`) requires `durationMinutes`, string-enum energy, and a slot `startTime` (Unix timestamp). So any client that builds a call from the published schema gets a **400 every time** — the tool is effectively unusable as documented.

## Fix
Align `index.npm.ts`'s `solve_schedule` `inputSchema` to the API contract (matches the already-correct `src/index.ts`):
- tasks: `{id, name, durationMinutes, priority, energyRequired(enum), deadline?, category?}`, required `[id, name, durationMinutes, priority, energyRequired]`
- slots: `{id, startTime, durationMinutes, energyLevel(enum)}`, required `[id, startTime, durationMinutes, energyLevel]`

Verified the contract against the API's zod schema (`ScheduleTaskSchema`/`TimeSlotSchema`) and the scheduler, which indexes `energyMatch[energyRequired][energyLevel]` with string keys.

`tsc` typecheck of the file is clean. Schema-only change; requires an npm republish to reach end users.